### PR TITLE
Filme hinzugefügt

### DIFF
--- a/index.md
+++ b/index.md
@@ -1,3 +1,11 @@
 # Daniel Brühl
 
-Daniel Brühl ist ein Schauspieler, der sich in den letzten 15 Jahren im deutschen sowie internationalen Kino einen Namen gemacht hat. Sein Durchbruch gelang ihm mit dem DDR-Drama "Goodbye, Lenin!". Daniel Brühl hat Wurzeln in Bacelona.
+Daniel Brühl ist ein Schauspieler, der sich in den letzten 15 Jahren im deutschen sowie internationalen Kino einen Namen gemacht hat. Sein Durchbruch gelang ihm mit dem DDR-Drama "Good Bye, Lenin!". Daniel Brühl hat Wurzeln in Bacelona.
+
+## Die wichtigsten Filme, in denen Daniel Brühl außerdem mitgespielt hat
+
+* Die fetten Jahre sind vorbei
+* Inglourious Bastards
+* Ein Freund von mir
+* Colonia Dignidad
+* Lila, lila


### PR DESCRIPTION
Die wichtigsten Filme, in denen Daniel Brühl mitgespielt hat, wurden hinzugefügt.
Fixes: #5 